### PR TITLE
Add _Alarm records

### DIFF
--- a/motorSimApp/Db/basic_asyn_motor.db
+++ b/motorSimApp/Db/basic_asyn_motor.db
@@ -23,6 +23,14 @@ record(motor,"$(P)$(M)")
     info(autosaveFields, "DIR DHLM DLLM TWV SREV MRES ERES RRES VBAS VELO VMAX ACCL BDST BVEL BACC RDBD DESC EGU RTRY UEIP URIP DLY RDBL PREC DISA DISP FOFF OFF FRAC OMSL JVEL JAR PCOF ICOF DCOF HVEL NTM NTMF")
 }
 
+record(ai, "$(P)$(M)_Alarm") {
+    field(INP, "$(P)$(M).RBV CP")
+    field(HIHI, "15.0")
+    field(LOLO, "-15.0")
+    field(HHSV, "MAJOR")
+    field(LLSV, "MAJOR")
+}
+
 record(transform, "$(P)$(M)_ableput") {
   field(CLCB, "a")
   field(CLCC, "a")


### PR DESCRIPTION
Since the motor record cannot be driven into alarm state this ai records simply provides a simulated alarm for the training exercises

@mdavidsaver 